### PR TITLE
clone_wp_site.py: Fix error when cloning locally

### DIFF
--- a/examples/clone_wp_site.py
+++ b/examples/clone_wp_site.py
@@ -69,7 +69,7 @@ def main(args):
     sqlpasswd_filepath_remote = f'/home/{DST_OSUSER_NAME}/{DST_APP_NAME}.sqlpasswd'
 
     sql_filepath_local = os.path.expanduser(f'~/{DST_APP_NAME}.sql')
-    sql_filepath_remote = f'/home/{DST_OSUSER_NAME}/{DST_APP_NAME}.sql'
+    sql_filepath_remote = f'/home/{DST_OSUSER_NAME}/{DST_APP_NAME}_remote.sql'
 
     # Retrieve web_server and primary IP entries for later use
     log.info(f'Retrieving webserver information for {DST_WEB_SERVER_HOSTNAME}')
@@ -149,7 +149,7 @@ def main(args):
     sshrunner.run_passbased_rsync(f'{src_app_path}/', f'{userhost}:{dst_app_path}/')
 
     log.info(f'Copying database content')
-    sshrunner.run_passbased_scp(sql_filepath_local, f'{userhost}:')
+    sshrunner.run_passbased_scp(sql_filepath_local, f'{userhost}:{sql_filepath_remote}')
     os.remove(sql_filepath_local)
 
     log.info(f'Importing database')


### PR DESCRIPTION
This PR is one way to fix issue #6. I chose to give the local and remote sql files unique names. This allows local and remote clones to both work without introducing conditional logic.