### PR TITLE
clone_wp_site.py: Update database config properly

### DIFF
--- a/examples/clone_wp_site.py
+++ b/examples/clone_wp_site.py
@@ -148,6 +148,12 @@ def main(args):
     log.info(f'Copying files')
     sshrunner.run_passbased_rsync(f'{src_app_path}/', f'{userhost}:{dst_app_path}/')
 
+    log.info(f'Updating database configuration')
+    sshrunner.run_passbased_ssh(f'/home/{DST_OSUSER_NAME}/bin/wp --path={dst_app_path} config set DB_HOST {dst_db_host}')
+    sshrunner.run_passbased_ssh(f'/home/{DST_OSUSER_NAME}/bin/wp --path={dst_app_path} config set DB_USER {dst_db_user}')
+    sshrunner.run_passbased_ssh(f'/home/{DST_OSUSER_NAME}/bin/wp --path={dst_app_path} config set DB_PASSWORD {dst_db_pass}')
+    sshrunner.run_passbased_ssh(f'/home/{DST_OSUSER_NAME}/bin/wp --path={dst_app_path} config set DB_NAME {dst_db_name}')
+
     log.info(f'Copying database content')
     sshrunner.run_passbased_scp(sql_filepath_local, f'{userhost}:')
     os.remove(sql_filepath_local)


### PR DESCRIPTION
This is a fix for issue #8. It updates the dst app to use the dst database, as intended.

It does this immediately after copying the files so that if any later steps of the script fail, we don't wind up with an app that appears to work because it's pointing to the src database.