### PR TITLE
Add app mark_installed action

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = opalstack
-version = 1.0.2
+version = 1.0.3
 author = Opalstack
 author_email = support@opalstack.com
 description = Opalstack API Python Library

--- a/src/opalstack/__init__.py
+++ b/src/opalstack/__init__.py
@@ -1,4 +1,4 @@
-VERSION = '1.0.2'
+VERSION = '1.0.3'
 __version__ = VERSION
 
 from .api import Api

--- a/src/opalstack/api.py
+++ b/src/opalstack/api.py
@@ -131,7 +131,7 @@ class Api():
         pending_uuids = list(uuids)
         i = 0
         while True:
-            #time.sleep(delay)
+            time.sleep(delay)
             i += 1
             log.debug(f'Checking deleted ({i}/{tries}) for {model_name} uuids: {repr(pending_uuids)}')
             for uuid in pending_uuids:

--- a/src/opalstack/apps.py
+++ b/src/opalstack/apps.py
@@ -16,6 +16,8 @@ class AppsManager(ApiModelManager):
     def update_one(self, *args, **kwargs): return super().update_one(*args, **kwargs)
     def delete(self, *args, **kwargs):     return super().delete(*args, **kwargs)
     def delete_one(self, *args, **kwargs): return super().delete_one(*args, **kwargs)
+    def mark_installed(self, app_ids):
+        self.api.http_post_result(f'/app/installed/', [{'id': app_id} for app_id in app_ids], ensure_status=[200])
 
     def check_equals(self, a, b):
         return ( a['name'] == b['name'] and

--- a/tests/test_psqltool.py
+++ b/tests/test_psqltool.py
@@ -75,7 +75,7 @@ def remote_psqldb(psqluser_server, remote_psqluser):
 
 def test_psqltool(psqluser_server, local_psqluser, local_psqldb, remote_osuser, remote_psqluser, remote_psqldb):
     # Some time for pg_hba update
-    time.sleep(45)
+    time.sleep(60)
 
     this_psqltool = PsqlTool('localhost', 5432, local_psqluser['name'], local_psqluser['default_password'], local_psqldb['name'], 'this.sqlpasswd')
     this_psqltool.export_local_db('this.sql')


### PR DESCRIPTION
This PR adds an app **mark_installed** action that marks the install completion for applications. This is intended for app install scripts which utilize opalstack-python internally.

The PR also fixes one minor bug and one intermittent unit test.